### PR TITLE
feat: export constants

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@ import * as IlpPacket from 'ilp-packet'
 import { Reader, Writer } from 'oer-utils'
 import { readUuid, writeUuid } from './uuid'
 
-const CCP_CONTROL_DESTINATION = 'peer.route.control'
-const CCP_UPDATE_DESTINATION = 'peer.route.update'
-const PEER_PROTOCOL_FULFILLMENT = Buffer.alloc(32)
-const PEER_PROTOCOL_CONDITION = Buffer.from('Zmh6rfhivXdsj8GLjp+OIAiXFIVu4jOzkCpZHQ1fKSU=', 'base64')
+export const CCP_CONTROL_DESTINATION = 'peer.route.control'
+export const CCP_UPDATE_DESTINATION = 'peer.route.update'
+export const PEER_PROTOCOL_FULFILLMENT = Buffer.alloc(32)
+export const PEER_PROTOCOL_CONDITION = Buffer.from('Zmh6rfhivXdsj8GLjp+OIAiXFIVu4jOzkCpZHQ1fKSU=', 'base64')
 const PEER_PROTOCOL_EXPIRY_DURATION = 60000
 
 export enum Mode {


### PR DESCRIPTION
Certain values are guaranteed not to change, so we can expose them.

Choosing not to expose the expiry duration, because that might be handled differently in the future (e.g. it might be a configurable parameter), so maybe better not to expose that if it might go away.