### PR TITLE
Refactor/Feat: Handle ILP packets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -907,6 +907,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1231,7 +1232,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -1315,6 +1317,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1361,7 +1364,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -1627,7 +1631,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,10 +75,6 @@ export interface CcpRouteUpdateResponse {
   // empty
 }
 
-/******************************************
- * Route Control Request
- *****************************************/
-
 const deserializeCcpRouteControlRequestPayload = (data: Buffer): CcpRouteControlRequest => {
   const reader = new Reader(data)
 
@@ -155,10 +151,6 @@ const constructCcpRouteControlRequest = (request: CcpRouteControlRequest): IlpPr
 const serializeCcpRouteControlRequest = (request: CcpRouteControlRequest): Buffer => {
   return serializeIlpPrepare(constructCcpRouteControlRequest(request))
 }
-
-/******************************************
- * Route Control Update
- *****************************************/
 
 const deserializeCcpRouteUpdateRequestPayload = (payload: Buffer): CcpRouteUpdateRequest => {
   const reader = new Reader(payload)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,12 +1,32 @@
 import * as CCP from '../src'
 import { assert } from 'chai'
 import { useFakeTimers } from 'sinon'
+import { deserializeIlpPacket, deserializeIlpPrepare, IlpPrepare } from 'ilp-packet'
 
 const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 
 describe('CCP', function () {
   beforeEach(function () {
     this.clock = useFakeTimers(START_DATE)
+  })
+
+  describe('extractCcpRouteControlRequest', function () {
+    it('should extract a CCP control request', function () {
+      const ccpPacket: IlpPrepare = {
+        amount: '0',
+        expiresAt: new Date('2015-06-16T00:01:00.000Z'),
+        destination: 'peer.route.control',
+        executionCondition: Buffer.from('66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925' , 'hex'),
+        data: Buffer.from('0170d1a134a0df4f47964f6e19e2ab379000000020010203666f6f03626172', 'hex')
+      }
+
+      assert.deepEqual(CCP.extractCcpRouteControlRequest(ccpPacket), {
+        mode: CCP.Mode.MODE_SYNC,
+        lastKnownRoutingTableId: '70d1a134-a0df-4f47-964f-6e19e2ab3790',
+        lastKnownEpoch: 32,
+        features: ['foo', 'bar']
+      })
+    })
   })
 
   describe('deserializeCcpControlRequest', async function () {


### PR DESCRIPTION
Refactor the various functions to allow for unserialised ILP packets to get the data out of the CCP Requests and Updates